### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,19 +12,19 @@ LedMatrixSPI	KEYWORD1
 # Methods and Functions (KEYWORD2)  #
 #####################################
 
-intensity   KEYWORD2
-shutdown    KEYWORD2
-setFont     KEYWORD2
-setLed      KEYWORD2
-update      KEYWORD2
-clear       KEYWORD2
-clearScreen KEYWORD2
-scrollDelay KEYWORD2
-printChar   KEYWORD2
-scrollChar  KEYWORD2
-line        KEYWORD2
-triangle    KEYWORD2
-quad        KEYWORD2
-rect        KEYWORD2
-circle      KEYWORD2
-ellipse     KEYWORD2
+intensity	KEYWORD2
+shutdown	KEYWORD2
+setFont	KEYWORD2
+setLed	KEYWORD2
+update	KEYWORD2
+clear	KEYWORD2
+clearScreen	KEYWORD2
+scrollDelay	KEYWORD2
+printChar	KEYWORD2
+scrollChar	KEYWORD2
+line	KEYWORD2
+triangle	KEYWORD2
+quad	KEYWORD2
+rect	KEYWORD2
+circle	KEYWORD2
+ellipse	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords